### PR TITLE
Fixed large dataset issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.env
+testing.py

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This program allows for a user to download call recordings for every Zendesk tic
 
 The program uses the Zendesk API to make calls for ticket information and is written in Python using additional libraries for the UI and storing user settings. The UI is created using the Tkinter Python Library, which does the job, even if it isn't the most modern looking.
 
-The options menu gives you the ability to change the credentials that are used to access the Zendesk API and some basic preferences such as file extension.
+The options menu gives you the ability to change the credentials that are used to access the Zendesk API and some basic preferences such as file extension. The date selection is inclusive.
 
 ## To access the Zendesk API for your domain, you'll need the following information:
  ### Your Zendesk domain
@@ -33,4 +33,4 @@ The options menu gives you the ability to change the credentials that are used t
  `pyinstaller main.pyw --distpath "<path/to/folder>" --workpath "<path/to/folder>" --noconsole --onefile --icon=zendesk_call_downloader.ico --name "Zendesk Call Downloader"`
 
  ## Repo Maintaining
- This project is uploaded to a Github account managed linked to a company managed email address. You can find my personal account at [Pricey1600](https://github.com/Pricey1600).
+ This project is uploaded to a Github account linked to a company managed email address. You can find my personal account at [Pricey1600](https://github.com/Pricey1600).

--- a/main.pyw
+++ b/main.pyw
@@ -40,10 +40,13 @@ END_DATE = "2025-01-03"
 #Used for stopping the searching/downloading process
 stop_process = False
 process_running = False
+downloading_running = False
+progress_bar_changed = False
 
 #Time to wait (seconds) between downloads to try and stay within API rate limits
 rate_limit_delay = 0.2
 
+TICKETS_SEARCHED = 0
 TOTAL_CALLS = 0
 
 def set_up():
@@ -91,7 +94,7 @@ def load_UI():
     dates_labelFrame.grid(row=2, column=0, columnspan=2, pady=10)
     start_date_label = ttk.Label(dates_labelFrame, text='Start Date')
     start_date_label.grid(row=0, column=0, sticky=E, pady=20)
-    ToolTip(start_date_label, msg="The start of the date range to search (exclusive)", delay=2.0)
+    ToolTip(start_date_label, msg="The start of the date range to search (inclusive)", delay=2.0)
 
     todays_date = date.today()
     global cal_start
@@ -103,7 +106,7 @@ def load_UI():
 
     end_date_label = Label(dates_labelFrame, text='End Date')
     end_date_label.grid(row=1, column=0, sticky=E, pady=20)
-    ToolTip(end_date_label, msg="The end of the date range to search (exclusive)", delay=2.0)
+    ToolTip(end_date_label, msg="The end of the date range to search (inclusive)", delay=2.0)
     global cal_end
     cal_end = Calendar(dates_labelFrame, selectmode = 'day', date_pattern="yyy-mm-dd",
                year = todays_date.year, month = todays_date.month,
@@ -261,8 +264,14 @@ def get_date_range():
     START_DATE = cal_start.get_date()
     END_DATE = cal_end.get_date()
 
-    print("Start Date: "+START_DATE)
-    print("End Date: "+END_DATE)
+    # Add times to dates
+    START_DATE = START_DATE + " 00:00:00"
+    START_DATE = datetime.strptime(START_DATE, '%Y-%m-%d %H:%M:%S')
+    END_DATE = END_DATE + " 23:59:59"
+    END_DATE = datetime.strptime(END_DATE, '%Y-%m-%d %H:%M:%S')
+
+    print("Start Date: "+str(START_DATE.isoformat()))
+    print("End Date: "+str(END_DATE.isoformat()))
 
 def download_call_recording(ticket_id):
     """
@@ -312,11 +321,9 @@ def download_call_recording(ticket_id):
         # -----------------------------------------------------------
         print(f"Downloading audio file(s) for ticket {ticket_id}...")
         recording_counter = 0
+        global TOTAL_CALLS
 
         for recording in recording_urls:
-            global TOTAL_CALLS
-            TOTAL_CALLS += 1
-            return # Here for testing
             audio_response = requests.get(recording, stream=True, auth=AUTH)
             
             #check the status codes of the response
@@ -333,6 +340,8 @@ def download_call_recording(ticket_id):
             
             save_path = PATH_FOLDER + new_filename + FILE_TYPE
             
+            TOTAL_CALLS += 1
+
             with open(save_path, 'wb') as f:
                 for chunk in audio_response.iter_content(chunk_size=8192):
                     f.write(chunk)
@@ -353,7 +362,7 @@ def find_tickets_with_recordings(start_date_str, end_date_str):
     """
     Finds call recordings for tickets created within a specified date range.
     """
-    global stop_process, start_button, cancel_button, process_running, rate_limit_delay
+    global stop_process, start_button, cancel_button, process_running, rate_limit_delay, downloading_running, tickets_to_search, TICKETS_SEARCHED
 
     process_running = True
 
@@ -394,7 +403,10 @@ def find_tickets_with_recordings(start_date_str, end_date_str):
                 if stop_process == True:
                     return
                 ticket_id = ticket['id']
-                tickets.append(ticket_id)
+                if ticket_id not in tickets:
+                    tickets.append(ticket_id)
+
+            print("--- Tickets Found So Far: "+str(len(tickets))+" ---")
                 
             if next_page_url:
                 parsed_url = urlparse(next_page_url)
@@ -425,11 +437,14 @@ def find_tickets_with_recordings(start_date_str, end_date_str):
                 break
             
         tickets_to_search = len(tickets)
+        print("--- Tickets Found: "+str(tickets_to_search)+" ---")
+        downloading_running = True
         for ticket in tickets:
             if stop_process:
                 return
             download_call_recording(ticket)
             tickets_to_search -= 1
+            TICKETS_SEARCHED += 1
             print("Tickets Left: "+str(tickets_to_search))
             Time.sleep(rate_limit_delay) # Add a small delay
 
@@ -452,14 +467,14 @@ def get_ticket_date(ticket_id):
     ticket_response.raise_for_status()
 
     ticket_data = ticket_response.json()
-    print("Ticket Result: "+str(ticket_data))
+    #print("Ticket Result: "+str(ticket_data))
 
     if 'audits' in ticket_data and ticket_data['audits']:
-        for audit in reversed(ticket_data['audits']):
+        for audit in ticket_data['audits']:
             continue_start_date = audit.get('created_at')
             print("Last ticket date: "+continue_start_date)
             #query = f"type:ticket created>{continue_start_date} created<{end_date_str}"
-            start_date_str = continue_start_date[:10]
+            start_date_str = continue_start_date
             print(start_date_str)
             return start_date_str
 
@@ -475,9 +490,9 @@ def validate_settings():
         return("Something went wrong when checking the save location.")
 
     #Validate dates
-    if len(START_DATE) < 10 or len(END_DATE) < 10:
-        return("Something went wrong when checking the date range.")
-    elif datetime.strptime(START_DATE, '%Y-%m-%d').date() > date.today() or datetime.strptime(END_DATE, '%Y-%m-%d').date() > (date.today() + timedelta(1)):
+    # if len(START_DATE) < 10 or len(END_DATE) < 10:
+    #     return("Something went wrong when checking the date range.")
+    if START_DATE > datetime.now() or END_DATE > ((datetime.now()+ timedelta(1))):
         return("Start and End dates cannot be in the future.")
     
     return True
@@ -512,9 +527,9 @@ def start_process():
             if char not in date_format:
                 date_format = date_format+"%"+char+"-"
         date_format=date_format[:8]
-        start_date = datetime.strptime(START_DATE, '%Y-%m-%d').date()
+        start_date = START_DATE.date()
         start_date_display = start_date.strftime(date_format)
-        end_date = datetime.strptime(END_DATE, '%Y-%m-%d').date()
+        end_date = END_DATE.date()
         end_date_display = end_date.strftime(date_format)
 
         #Get final confirmation
@@ -533,7 +548,7 @@ def start_process():
         global progress_bar, cancel_button, start_button, t2, stop_process
 
         #t2 is the thread for the searching/downloading process
-        t2 = threading.Thread(target=find_tickets_with_recordings, args=(START_DATE, END_DATE))
+        t2 = threading.Thread(target=find_tickets_with_recordings, args=(str(START_DATE.isoformat())+'Z', str(END_DATE.isoformat())+'Z'))
 
         cancel_button.grid(row=3, column=1, sticky=W, pady=(10, 20))
         start_button.grid_remove()
@@ -550,6 +565,8 @@ def cancel_process():
     global stop_process, progress_bar, process_running
 
     progress_bar.stop()
+    progress_bar.configure(mode='indeterminate')
+    progress_bar['value'] = 0
     progress_bar.grid_remove()
 
     cancel_button.grid_remove()
@@ -562,13 +579,23 @@ def cancel_process():
         show_message("info", "Downloading Complete", "The process has completed. All found recordings have been downloaded to your selected location. Please ensure these are handled in-line with data protection regulations.")
 
 def main_loop():
-    global root, t2, process_running
+    global root, t2, process_running, progress_bar, downloading_running, tickets_to_search, TICKETS_SEARCHED
     while True:
-        root.update()
+        if(downloading_running and TICKETS_SEARCHED == 0):
+            #update progress bar mode and max value
+            progress_bar.configure(mode='determinate', maximum=(tickets_to_search+1))
         # Check if process has finished running
         if(process_running and t2.is_alive() != True):
             process_running = False
+            downloading_running = False
+            TICKETS_SEARCHED = 0
             cancel_process()
+        elif downloading_running:
+            #update progress bar
+            progress_bar['value'] = TICKETS_SEARCHED
+        
+        # Update the window
+        root.update()
 
 def quit():
     global t2, stop_process

--- a/main.pyw
+++ b/main.pyw
@@ -174,7 +174,7 @@ def save_prefs(extension, date_format):
     prefs_popup.destroy()
 
 def load_settings():
-    global ZENDESK_SUBDOMAIN, ZENDESK_EMAIL, ZENDESK_TOKEN, FILE_TYPE, DATE_DISPLAY_FORMAT
+    global ZENDESK_SUBDOMAIN, ZENDESK_EMAIL, ZENDESK_TOKEN, FILE_TYPE, DATE_DISPLAY_FORMAT, BASE_URL, AUTH
 
     if (os.path.isfile('.env')):
         #load from .env file. Override if already loaded
@@ -183,10 +183,12 @@ def load_settings():
         # Load environment variables if they exist
         if ("SUBDOMAIN" in os.environ):
             ZENDESK_SUBDOMAIN = os.getenv("SUBDOMAIN")
+            BASE_URL = f"https://{ZENDESK_SUBDOMAIN}.zendesk.com/api/v2"
         if ("EMAIL" in os.environ):
             ZENDESK_EMAIL = os.getenv("EMAIL")
         if ("API_TOKEN" in os.environ):
             ZENDESK_TOKEN = os.getenv("API_TOKEN")
+        AUTH = (f"{ZENDESK_EMAIL}/token", ZENDESK_TOKEN)
         if ("FILE_TYPE" in os.environ):
             FILE_TYPE = os.getenv("FILE_TYPE")
         if ("DATE_DISPLAY" in os.environ):
@@ -355,8 +357,8 @@ def download_call_recording(ticket_id):
             print(f"Download complete. File saved as: {new_filename}")
 
     except requests.exceptions.HTTPError as err:
-            print(f"HTTP Error: {err}")
-            STATUS = (f"HTTP Error: {err}")
+        print(f"HTTP Error: {err}")
+        STATUS = (f"HTTP Error: {err}")
     except requests.exceptions.RequestException as err:
         print(f"An error occurred: {err}")
         STATUS = (f"An error occurred: {err}")
@@ -389,7 +391,8 @@ def find_tickets_with_recordings(start_date_str, end_date_str):
     try:
         if stop_process == True:
             return
-        STATUS = (f"\n--- Starting search for voice tickets from {current_start_date} up to {end_date} ---")
+        STATUS = (f"Starting search for voice tickets from {current_start_date} up to {end_date}...")
+        print(f"\n--- Starting search for voice tickets from {current_start_date} up to {end_date} ---")
 
         while next_page_url:
             print(f"\nFetching page from URL: {next_page_url}")
@@ -397,12 +400,14 @@ def find_tickets_with_recordings(start_date_str, end_date_str):
             
             if not data or 'results' not in data:
                 STATUS = ("No more results or an unrecoverable API error occurred.")
+                print("No more results or an unrecoverable API error occurred.")
                 break
 
             results = data['results']
             
             if not results:
                 STATUS = ("Current page has no tickets within the current criteria. Finishing search.")
+                print("Current page has no tickets within the current criteria. Finishing search.")
                 break
 
             next_page_url = data.get('next_page')
@@ -453,6 +458,8 @@ def find_tickets_with_recordings(start_date_str, end_date_str):
             download_call_recording(ticket)
             tickets_to_search -= 1
             TICKETS_SEARCHED += 1
+            if stop_process == True:
+                return
             STATUS = ("Searching tickets for recordings. Tickets Left: "+str(tickets_to_search))
             Time.sleep(rate_limit_delay) # Add a small delay
 
@@ -580,10 +587,11 @@ def cancel_process():
     progress_bar['value'] = 0
     progress_bar.grid_remove()
 
-    cancel_button.grid_remove()
-    start_button.grid(row=3, column=1, sticky=W, pady=(10, 20))
+    cancel_button.config(state=tk.DISABLED)
+    # cancel_button.grid_remove()
+    # start_button.grid(row=3, column=1, sticky=W, pady=(10, 20))
 
-    status_label.grid_remove()
+    # status_label.grid_remove()
 
     if(process_running):
         print("--- Cancelling Process ---")
@@ -591,8 +599,16 @@ def cancel_process():
         stop_process = True
     elif(stop_process == True):
         show_message("warning", "Process Cancelled", "The process has been cancelled. All found recordings have been downloaded to your selected location. Please ensure these are handled in-line with data protection regulations.")
+        cancel_button.config(state=tk.NORMAL)
+        cancel_button.grid_remove()
+        start_button.grid(row=3, column=1, sticky=W, pady=(10, 20))
+        status_label.grid_remove()
     else:
         show_message("info", "Downloading Complete", "The process has completed. All found recordings have been downloaded to your selected location. Please ensure these are handled in-line with data protection regulations.")
+        cancel_button.config(state=tk.NORMAL)
+        cancel_button.grid_remove()
+        start_button.grid(row=3, column=1, sticky=W, pady=(10, 20))
+        status_label.grid_remove()
 
 def main_loop():
     global root, t2, process_running, progress_bar, downloading_running, tickets_to_search, TICKETS_SEARCHED, STATUS, status_label

--- a/main.pyw
+++ b/main.pyw
@@ -48,6 +48,7 @@ rate_limit_delay = 0.2
 
 TICKETS_SEARCHED = 0
 TOTAL_CALLS = 0
+STATUS = "PREPARING..."
 
 def set_up():
     print("Starting Zendesk Call Recording Download Tool...")
@@ -61,7 +62,7 @@ def load_UI():
     global root
     root = tk.Tk()
     #root.withdraw()
-    root.geometry("500x850")
+    root.geometry("500x870")
     root.title("Zendesk Call Downloading")
     # Set the window icon.
     root.iconbitmap(sys.executable)
@@ -123,6 +124,9 @@ def load_UI():
 
     exit_button = ttk.Button(root, text="Quit", command=quit)
     exit_button.grid(row=3, column=0, sticky=E, pady=(10, 20))
+
+    global status_label
+    status_label = ttk.Label(root, text=STATUS, wraplength=400, justify=CENTER)
 
     global progress_bar
     progress_bar = ttk.Progressbar(root, orient = HORIZONTAL, length = 400, mode = 'indeterminate')
@@ -280,7 +284,7 @@ def download_call_recording(ticket_id):
     This function uses the Zendesk API to fetch the latest audit for a ticket,
     which may contain the call recording URL. It then downloads the file.
     """
-    
+    global STATUS
     # -----------------------------------------------------------
     # API Endpoints
     # -----------------------------------------------------------
@@ -352,19 +356,23 @@ def download_call_recording(ticket_id):
 
     except requests.exceptions.HTTPError as err:
             print(f"HTTP Error: {err}")
+            STATUS = (f"HTTP Error: {err}")
     except requests.exceptions.RequestException as err:
         print(f"An error occurred: {err}")
+        STATUS = (f"An error occurred: {err}")
     except Exception as err:
         print(f"An unexpected error occurred: {err}")
+        STATUS = (f"An unexpected error occurred: {err}")
     return True
 
 def find_tickets_with_recordings(start_date_str, end_date_str):
     """
     Finds call recordings for tickets created within a specified date range.
     """
-    global stop_process, start_button, cancel_button, process_running, rate_limit_delay, downloading_running, tickets_to_search, TICKETS_SEARCHED
+    global stop_process, start_button, cancel_button, process_running, rate_limit_delay, downloading_running, tickets_to_search, TICKETS_SEARCHED, STATUS
 
     process_running = True
+    STATUS = "Getting tickets..."
 
     current_start_date = start_date_str
     end_date = end_date_str
@@ -381,20 +389,20 @@ def find_tickets_with_recordings(start_date_str, end_date_str):
     try:
         if stop_process == True:
             return
-        print(f"\n--- Starting search for voice tickets from {current_start_date} up to {end_date} ---")
+        STATUS = (f"\n--- Starting search for voice tickets from {current_start_date} up to {end_date} ---")
 
         while next_page_url:
             print(f"\nFetching page from URL: {next_page_url}")
             data = _make_request(next_page_url, params)
             
             if not data or 'results' not in data:
-                print("No more results or an unrecoverable API error occurred.")
+                STATUS = ("No more results or an unrecoverable API error occurred.")
                 break
 
             results = data['results']
             
             if not results:
-                print("Current page has no tickets within the current criteria. Finishing search.")
+                STATUS = ("Current page has no tickets within the current criteria. Finishing search.")
                 break
 
             next_page_url = data.get('next_page')
@@ -445,18 +453,19 @@ def find_tickets_with_recordings(start_date_str, end_date_str):
             download_call_recording(ticket)
             tickets_to_search -= 1
             TICKETS_SEARCHED += 1
-            print("Tickets Left: "+str(tickets_to_search))
+            STATUS = ("Searching tickets for recordings. Tickets Left: "+str(tickets_to_search))
             Time.sleep(rate_limit_delay) # Add a small delay
 
     except requests.exceptions.HTTPError as err:
         print(f"HTTP Error: {err}")
         print("Please check your Zendesk subdomain, email, and API token or the date format.")
+        STATUS = "Please check your Zendesk subdomain, email, and API token or the date format."
     except requests.exceptions.RequestException as err:
         print(f"An error occurred: {err}")
     # except:
     #     print("Something has gone wrong")
     
-    print("\n--- Process complete ---")
+    STATUS = ("\n--- Process complete ---")
     print("Total Tickets found: "+str(len(tickets)))
     print("Total Calls Found: "+str(TOTAL_CALLS))
 
@@ -545,7 +554,7 @@ def start_process():
     if ZENDESK_SUBDOMAIN == None or ZENDESK_TOKEN == None:
         print("Something went wrong when populating the credentials.")
     else:
-        global progress_bar, cancel_button, start_button, t2, stop_process
+        global progress_bar, cancel_button, start_button, t2, stop_process, status_label
 
         #t2 is the thread for the searching/downloading process
         t2 = threading.Thread(target=find_tickets_with_recordings, args=(str(START_DATE.isoformat())+'Z', str(END_DATE.isoformat())+'Z'))
@@ -553,8 +562,10 @@ def start_process():
         cancel_button.grid(row=3, column=1, sticky=W, pady=(10, 20))
         start_button.grid_remove()
 
-        progress_bar.grid(row=4, columnspan=2)
+        progress_bar.grid(row=5, columnspan=2)
         progress_bar.start()
+
+        status_label.grid(row=4, columnspan=2)
 
         stop_process = False
         t2.start()
@@ -562,7 +573,7 @@ def start_process():
         #download_call_recording(ZENDESK_SUBDOMAIN, ZENDESK_EMAIL, ZENDESK_TOKEN, test_ticket_id)
 
 def cancel_process():
-    global stop_process, progress_bar, process_running
+    global stop_process, progress_bar, process_running, status_label, STATUS
 
     progress_bar.stop()
     progress_bar.configure(mode='indeterminate')
@@ -572,19 +583,26 @@ def cancel_process():
     cancel_button.grid_remove()
     start_button.grid(row=3, column=1, sticky=W, pady=(10, 20))
 
+    status_label.grid_remove()
+
     if(process_running):
         print("--- Cancelling Process ---")
+        STATUS = "Cancelling Process..."
         stop_process = True
+    elif(stop_process == True):
+        show_message("warning", "Process Cancelled", "The process has been cancelled. All found recordings have been downloaded to your selected location. Please ensure these are handled in-line with data protection regulations.")
     else:
         show_message("info", "Downloading Complete", "The process has completed. All found recordings have been downloaded to your selected location. Please ensure these are handled in-line with data protection regulations.")
 
 def main_loop():
-    global root, t2, process_running, progress_bar, downloading_running, tickets_to_search, TICKETS_SEARCHED
+    global root, t2, process_running, progress_bar, downloading_running, tickets_to_search, TICKETS_SEARCHED, STATUS, status_label
     while True:
         if(downloading_running and TICKETS_SEARCHED == 0):
             #update progress bar mode and max value
             progress_bar.configure(mode='determinate', maximum=(tickets_to_search+1))
         # Check if process has finished running
+        if (process_running):
+            status_label.configure(text=STATUS)
         if(process_running and t2.is_alive() != True):
             process_running = False
             downloading_running = False

--- a/main.pyw
+++ b/main.pyw
@@ -18,6 +18,9 @@ from dotenv import load_dotenv
 
 import threading
 
+from urllib.parse import urlparse, parse_qs
+
+
 #save location and file type variables
 PATH_FOLDER = "-"
 FILE_TYPE = ".mp3"
@@ -26,6 +29,8 @@ FILE_TYPE = ".mp3"
 ZENDESK_SUBDOMAIN = ""
 ZENDESK_EMAIL = ""
 ZENDESK_TOKEN = ""
+AUTH = ""
+BASE_URL = ""
 
 #Dates in yyyy-mm-dd format
 DATE_DISPLAY_FORMAT = "dd-mm-yyyy"
@@ -37,11 +42,16 @@ stop_process = False
 process_running = False
 
 #Time to wait (seconds) between downloads to try and stay within API rate limits
-rate_limit_delay = 1
+rate_limit_delay = 0.2
+
+TOTAL_CALLS = 0
 
 def set_up():
     print("Starting Zendesk Call Recording Download Tool...")
     load_settings()
+    global AUTH, BASE_URL
+    AUTH = (f"{ZENDESK_EMAIL}/token", ZENDESK_TOKEN)
+    BASE_URL = f"https://{ZENDESK_SUBDOMAIN}.zendesk.com/api/v2"
     load_UI()
 
 def load_UI():
@@ -254,7 +264,7 @@ def get_date_range():
     print("Start Date: "+START_DATE)
     print("End Date: "+END_DATE)
 
-def download_call_recording(zendesk_subdomain, zendesk_email, zendesk_token, ticket_id):
+def download_call_recording(ticket_id):
     """
     Downloads a call recording from a Zendesk ticket and renames it.
     
@@ -265,15 +275,14 @@ def download_call_recording(zendesk_subdomain, zendesk_email, zendesk_token, tic
     # -----------------------------------------------------------
     # API Endpoints
     # -----------------------------------------------------------
-    audits_url = f"https://{zendesk_subdomain}.zendesk.com/api/v2/tickets/{ticket_id}/audits.json"
-    auth = (f"{zendesk_email}/token", zendesk_token)
+    audits_url = f"https://{ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets/{ticket_id}/audits.json"
     
     print(f"Searching for recording for ticket {ticket_id}...")
     
     recording_urls = []
 
     try:
-        response = requests.get(audits_url, auth=auth)
+        response = requests.get(audits_url, auth=AUTH)
         response.raise_for_status()
         
         data = response.json()
@@ -305,8 +314,10 @@ def download_call_recording(zendesk_subdomain, zendesk_email, zendesk_token, tic
         recording_counter = 0
 
         for recording in recording_urls:
-
-            audio_response = requests.get(recording, stream=True, auth=auth)
+            global TOTAL_CALLS
+            TOTAL_CALLS += 1
+            return # Here for testing
+            audio_response = requests.get(recording, stream=True, auth=AUTH)
             
             #check the status codes of the response
             #410 - Missing file
@@ -338,64 +349,119 @@ def download_call_recording(zendesk_subdomain, zendesk_email, zendesk_token, tic
         print(f"An unexpected error occurred: {err}")
     return True
 
-def find_tickets_with_recordings(zendesk_subdomain, zendesk_email, zendesk_token, start_date_str, end_date_str):
+def find_tickets_with_recordings(start_date_str, end_date_str):
     """
-    Finds and downloads call recordings for tickets created within a specified date range.
+    Finds call recordings for tickets created within a specified date range.
     """
     global stop_process, start_button, cancel_button, process_running, rate_limit_delay
 
     process_running = True
+
+    current_start_date = start_date_str
+    end_date = end_date_str
     
-    search_url = f"https://{zendesk_subdomain}.zendesk.com/api/v2/search.json"
-    auth = (f"{zendesk_email}/token", zendesk_token)
+    query_template = (
+            f"type:ticket created>{current_start_date} created<{end_date}"
+        )
+    params = {'query': query_template, 'sort_by': 'created_at', 'sort_order': 'asc'}
+    search_url = f"{BASE_URL}/search.json"
     
-    # Zendesk search query for tickets created within the date range
-    query = f"type:ticket created>{start_date_str} created<{end_date_str}"
-    
-    params = {'query': query}
-    
-    print(f"Searching for tickets created between {start_date_str} and {end_date_str}...")
-    
-    has_more_results = True
     next_page_url = search_url
+    tickets = []
     
     try:
         if stop_process == True:
             return
-        while has_more_results:
-            response = requests.get(next_page_url, auth=auth, params=params if next_page_url == search_url else None)
-            response.raise_for_status()
-            data = response.json()
+        print(f"\n--- Starting search for voice tickets from {current_start_date} up to {end_date} ---")
+
+        while next_page_url:
+            print(f"\nFetching page from URL: {next_page_url}")
+            data = _make_request(next_page_url, params)
             
-            results = data.get('results', [])
-            if not results:
-                print("No tickets found in the specified date range.")
+            if not data or 'results' not in data:
+                print("No more results or an unrecoverable API error occurred.")
                 break
 
-            print("Number of tickets found: "+str(len(results)))
-                
+            results = data['results']
+            
+            if not results:
+                print("Current page has no tickets within the current criteria. Finishing search.")
+                break
+
+            next_page_url = data.get('next_page')
+   
             for ticket in results:
                 if stop_process == True:
                     return
                 ticket_id = ticket['id']
-                # The download_call_recording function handles checking for a recording
-                download_call_recording(zendesk_subdomain, zendesk_email, zendesk_token, ticket_id)
-                Time.sleep(rate_limit_delay) # Add a small delay
+                tickets.append(ticket_id)
                 
-            has_more_results = data.get('next_page') is not None
-            if has_more_results:
-                next_page_url = data['next_page']
-                print("Fetching next page of results...")
+            if next_page_url:
+                parsed_url = urlparse(next_page_url)
+                params = parse_qs(parsed_url.query)
+                page_num = int(params.get('page', ['1'])[0])
+
+                if page_num >= 11:
+                    # When we hit the limit, the last ticket processed contains the
+                    # checkpoint time for the *next* search iteration.
+                    last_ticket_created_at = get_ticket_date(tickets[-1])
+                    
+                    print("\n--- HIGH VOLUME ALERT: HITTING SEARCH LIMIT ---")
+                    print(f"Pagination limit reached (next page is {page_num}). Shifting start date.")
+                    
+                    # Update the current start date to the creation time of the last ticket
+                    current_start_date = last_ticket_created_at
+                    
+                    # Reset URL, query, and params; forcing it back to page 1
+                    query_template = (f"type:ticket created>{current_start_date} created<{end_date}")
+                    next_page_url = search_url
+                    params = {'query': query_template, 'sort_by': 'created_at', 'sort_order': 'asc'}
+                    
+                    print(f"New search range starts FROM: {current_start_date}")
+                    print("--- Continuing search with new checkpoint ---")
+                    
+            else:
+                # No next_page and not a date shift, so the search is fully complete.
+                break
             
+        tickets_to_search = len(tickets)
+        for ticket in tickets:
+            if stop_process:
+                return
+            download_call_recording(ticket)
+            tickets_to_search -= 1
+            print("Tickets Left: "+str(tickets_to_search))
+            Time.sleep(rate_limit_delay) # Add a small delay
+
     except requests.exceptions.HTTPError as err:
         print(f"HTTP Error: {err}")
         print("Please check your Zendesk subdomain, email, and API token or the date format.")
     except requests.exceptions.RequestException as err:
         print(f"An error occurred: {err}")
-    except:
-        print("Something has gone wrong")
+    # except:
+    #     print("Something has gone wrong")
     
     print("\n--- Process complete ---")
+    print("Total Tickets found: "+str(len(tickets)))
+    print("Total Calls Found: "+str(TOTAL_CALLS))
+
+def get_ticket_date(ticket_id):
+    audits_url = f"https://{ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets/{ticket_id}/audits.json"
+    #get the date and time of the last ticket
+    ticket_response = requests.get(audits_url, auth=AUTH)
+    ticket_response.raise_for_status()
+
+    ticket_data = ticket_response.json()
+    print("Ticket Result: "+str(ticket_data))
+
+    if 'audits' in ticket_data and ticket_data['audits']:
+        for audit in reversed(ticket_data['audits']):
+            continue_start_date = audit.get('created_at')
+            print("Last ticket date: "+continue_start_date)
+            #query = f"type:ticket created>{continue_start_date} created<{end_date_str}"
+            start_date_str = continue_start_date[:10]
+            print(start_date_str)
+            return start_date_str
 
 def validate_settings():
     print("Validating Settings...")
@@ -415,6 +481,22 @@ def validate_settings():
         return("Start and End dates cannot be in the future.")
     
     return True
+
+def _make_request(url, params):
+        """Helper to handle API requests, authentication, and error checking."""
+        try:
+            print("URL: "+ url)
+            response = requests.get(url, auth=AUTH, params=params)
+            response.raise_for_status()  # Raises HTTPError for bad responses (4xx or 5xx)
+            return response.json()
+        except requests.exceptions.HTTPError as err:
+            print(f"HTTP Error for {url}: {err}")
+            if response.status_code == 429:
+                print("Rate limit exceeded. Please wait and try again.")
+            return None
+        except requests.exceptions.RequestException as e:
+            print(f"An error occurred during request to {url}: {e}")
+            return None
     
 def start_process():
     
@@ -451,7 +533,7 @@ def start_process():
         global progress_bar, cancel_button, start_button, t2, stop_process
 
         #t2 is the thread for the searching/downloading process
-        t2 = threading.Thread(target=find_tickets_with_recordings, args=(ZENDESK_SUBDOMAIN, ZENDESK_EMAIL, ZENDESK_TOKEN, START_DATE, END_DATE))
+        t2 = threading.Thread(target=find_tickets_with_recordings, args=(START_DATE, END_DATE))
 
         cancel_button.grid(row=3, column=1, sticky=W, pady=(10, 20))
         start_button.grid_remove()


### PR DESCRIPTION
Fixed issue where getting over 1000 tickets (10+ pages at 100 per page) at once causes the program to only perform the operation for the first 1000. This is due to the Zendesk API not providing any more pages past page 10. To resolve this, I used date shifting once the 10th page had been fetched. Once the most recent fetched ticket's date has been obtained, it then makes a fresh call to the API with the new starting date (the ticket's creation date and time).

Also improved the progress bar to be determinative and added a status label to give more of an idea of progress or errors.